### PR TITLE
fixed a path in instructions at readme, also fixed executable in .pyr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Do the pre-setup for pyiron
 ```
 mv binder/.pyiron ~/
 mkdir ~/pyiron
-cp -rf binder/pyiron/resources ~/pyiron/
+cp -rf pyiron/resources ~/pyiron/
 ```
 
 You might need do `chmod u+x filename` for the files in the `pyiron/resources/paraprobe-ranger/bin` folder.

--- a/binder/.pyiron
+++ b/binder/.pyiron
@@ -1,3 +1,3 @@
 [DEFAULT]
-TOP_LEVEL_DIRS = /home/jovyan
-RESOURCE_PATHS = /srv/conda/envs/notebook/share/pyiron, /home/jovyan/pyiron/resources
+TOP_LEVEL_DIRS = $HOME
+RESOURCE_PATHS = pyiron, $HOME/pyiron/resources


### PR DESCRIPTION
absolute paths in config file made example notebooks fail. 